### PR TITLE
fix: handle Starlette 422 constant rename (UNPROCESSABLE_ENTITY → UNPROCESSABLE_CONTENT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/src/basalam/backbone_api/responses/client_error/unprocessable_content.py
+++ b/src/basalam/backbone_api/responses/client_error/unprocessable_content.py
@@ -1,7 +1,13 @@
 from typing import List
 
 from starlette.responses import JSONResponse
-from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
+try:
+    # Starlette >= 0.47 renamed this constant; the old name is deprecated.
+    from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT
+except ImportError:  # pragma: no cover - older Starlette
+    from starlette.status import (
+        HTTP_422_UNPROCESSABLE_ENTITY as HTTP_422_UNPROCESSABLE_CONTENT,
+    )
 
 from basalam.backbone_api.responses.client_error.base import Base400Response, Error
 
@@ -16,5 +22,5 @@ class UnprocessableContentResponse(Base400Response):
     def as_json_response(self) -> JSONResponse:
         return JSONResponse(
             content=self.model_dump(),
-            status_code=HTTP_422_UNPROCESSABLE_ENTITY
+            status_code=HTTP_422_UNPROCESSABLE_CONTENT
         )


### PR DESCRIPTION
Starlette >= 0.47 renamed `HTTP_422_UNPROCESSABLE_ENTITY` to `HTTP_422_UNPROCESSABLE_CONTENT` and emits a `StarletteDeprecationWarning` for the old name.

### Changes
- **`unprocessable_content.py`**: import `HTTP_422_UNPROCESSABLE_CONTENT`, with a fallback import to the old `HTTP_422_UNPROCESSABLE_ENTITY` (aliased) so projects still pinned to Starlette < 0.47 keep working without an `ImportError`. Both constants resolve to `422`, so behavior is unchanged.
- **`.gitignore`**: enable the `.idea/` rule (PyCharm per-user config).

### Compatibility
| Starlette | Behavior |
|---|---|
| `>= 0.47` | uses the new constant, no deprecation warning |
| `< 0.47` | falls back to the old constant, no ImportError |

🤖 Generated with [Claude Code](https://claude.com/claude-code)